### PR TITLE
Update for Laravel 11 and PHP 8.1+

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,20 +9,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: [10.*, 9.*, 8.*]
+        php: [8.3, 8.2, 8.1]
+        laravel: [11.*, 10.*, 9.*]
         stability: [prefer-stable]
         include:
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
             testbench: ^7.0
-          - laravel: 8.*
-            testbench: ^6.6
-        exclude:
-          - laravel: 10.*
-            php: 8.0
-
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can install the package via composer:
 composer require juampi92/laravel-query-cache
 ```
 
+This package supports Laravel 9 through 11 and requires PHP 8.1 or higher.
+
 That's it! No config or Trait necessary. The package auto-discovery will boot the macros.
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "illuminate/cache": "^8.0|^9.0|^10.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "php": ">=8.1",
+        "illuminate/cache": "^9.0|^10.0|^11.0",
+        "illuminate/database": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^v7.0",
+        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         failOnRisky="false"
+         failOnWarning="false"
+         failOnDeprecation="false"
          processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
->
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Juampi92 Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
## Summary
- support Laravel 9-11 and PHP 8.1+
- update CI matrix for PHP 8.3, 8.2, 8.1 and drop Laravel 8
- document updated compatibility in README

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6847fce4495c83329107aae860eb183d